### PR TITLE
Split date parsing to it's own function

### DIFF
--- a/main.go
+++ b/main.go
@@ -340,7 +340,7 @@ func (j *Job) parseString(s string) error {
 	if strings.Trim(content[0], " ") == "" {
 		content = content[1:]
 	}
-	date, err := time.Parse("2006-01-02 15:04", content[1])
+	date, err := parseDate(content[1])
 	if err != nil {
 		return err
 	}
@@ -350,4 +350,42 @@ func (j *Job) parseString(s string) error {
 	j.Description = strings.Join(content[2:], "\n")
 
 	return nil
+}
+
+func parseDate(s string) (time.Time, error) {
+
+	date, err := time.Parse("2006-01-02 15:04", s)
+	if err == nil {
+		return date, nil
+	}
+	date, err = time.Parse("2006-01-02 03:04PM", s)
+	if err == nil {
+		return date, nil
+	}
+	date, err = time.Parse("2006/01/02 15:04", s)
+	if err == nil {
+		return date, nil
+	}
+	date, err = time.Parse("2006/01/02 03:04PM", s)
+	if err == nil {
+		return date, nil
+	}
+	date, err = time.Parse("01-02-2006 15:04", s)
+	if err == nil {
+		return date, nil
+	}
+	date, err = time.Parse("01-02-2006 03:04PM", s)
+	if err == nil {
+		return date, nil
+	}
+	date, err = time.Parse("01/02/2006 15:04", s)
+	if err == nil {
+		return date, nil
+	}
+	date, err = time.Parse("01/02/2006 03:04PM", s)
+	if err == nil {
+		return date, nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date format provided, please provide date in the format Year-Month-Day 24:00")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -54,7 +55,7 @@ func TestJob_parseString(t *testing.T) {
 				Description: "Test string\ngoes here",
 			},
 			args: args{
-				s: "\nTest\n2006/01/02 17:00\nTest string\ngoes here",
+				s: "\nTest\nJan 1 2021 5PM\nTest string\ngoes here",
 			},
 			wantErr: true,
 		},
@@ -75,6 +76,107 @@ func TestJob_parseString(t *testing.T) {
 				if j.Description != tt.fields.Description {
 					t.Errorf("Job.parseString() expected Description = %v, got Description = %v", tt.fields.Description, j.Description)
 				}
+			}
+		})
+	}
+}
+
+func TestJob_parseDate(t *testing.T) {
+	expDate, _ := time.Parse("2006-01-02 15:04", "2021-01-01 17:00")
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "Year-Month-Day date with hyphens and 24 hour time",
+			args: args{
+				s: "2021-01-01 17:00",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Year-Month-Day date with hyphens and 12 hour time",
+			args: args{
+				s: "2021-01-01 05:00PM",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Year-Month-Day date with slashes and 24 hour time",
+			args: args{
+				s: "2021/01/01 17:00",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Year-Month-Day  date with slashes and 12 hour time",
+			args: args{
+				s: "2021/01/01 05:00PM",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Day-Month-Year date with hyphens and 24 hour time",
+			args: args{
+				s: "01-01-2021 17:00",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Day-Month-Year date with hyphens and 12 hour time",
+			args: args{
+				s: "01-01-2021 05:00PM",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Day-Month-Year date with slashes and 24 hour time",
+			args: args{
+				s: "01/01/2021 17:00",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Day-Month-Year date with slashes and 12 hour time",
+			args: args{
+				s: "01/01/2021 05:00PM",
+			},
+			want:    expDate,
+			wantErr: false,
+		},
+		{
+			name: "Invalid date",
+			args: args{
+				s: "Jan 1 2021 5PM",
+			},
+			want:    time.Time{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDate(tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Job.parseDate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Job.parseDate() = %v, want %v", got, tt.want)
+			}
+			if tt.wantErr && err.Error() != "invalid date format provided, please provide date in the format Year-Month-Day 24:00" {
+				t.Errorf("Job.parseDate() error = %v, wantErr %v", err, "invalid date format provided, please provide date in the format Year-Month-Day 24:00")
 			}
 		})
 	}


### PR DESCRIPTION
To support multiple date formats we'll need a dedicated function for
date parsing to keep the code clean. Added some tests for the supported
date formats and updated the Job creation tests to match supported
formats.